### PR TITLE
reorder AdminHelp CMSFields to improve usability

### DIFF
--- a/code/models/AdminHelp.php
+++ b/code/models/AdminHelp.php
@@ -10,9 +10,9 @@ class AdminHelp extends DataObject
 {
 	private static $db = array(
 		'Title' => 'Varchar(200)',
+		'UniqueIdentifier' => 'Varchar(255)', //lookup so records can be retrieved without ID
 		'Summary' => 'HTMLText',
 		'Content' => 'HTMLText',
-		'UniqueIdentifier' => 'Varchar(255)', //lookup so records can be retrieved without ID
 		'Sort' => 'Int'
 	);
 
@@ -34,14 +34,20 @@ class AdminHelp extends DataObject
 
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
+		$fields->removeByName('Sort');
+		$fields->removeByName('ParentID');
+		$fields->removeByName('Summary');
+		$fields->removeByName('Content');
+		$fields->removeByName('UniqueIdentifier');
 
 		$fields->addFieldsToTab('Root.Main', array(
 			TextField::create('Title'),
+			TreeDropdownField::create('ParentID', 'Parent', 'AdminHelp', 'ID', 'Title'),
+			TextField::create('UniqueIdentifier'),
 			HtmlEditorField::create('Summary')
 				->setDescription('Short summary to show on hover')
 				->setRows(5),
 			HtmlEditorField::create('Content')->setDescription('Content of help article'),
-			TreeDropdownField::create('ParentID', 'Parent', 'AdminHelp', 'ID', 'Title')
 		));
 
 		if ($childrenGrid = $fields->fieldByName('Root.Children.Children')) {


### PR DESCRIPTION
By putting the Dropdown and Text fields at the top, this fixes a couple of issues I had when adding help items.
1. The parent dropdown field dropdown list was dropping below the screen, so I was having to open the dropdown, then scroll the screen down to select the parent from the list.
2. Sometimes I would forget to set the parent id and unique identifier because I would add the content and not scroll to the bottom of the content wysiwyg to see those other fields... And forget they were there!
3. Removes Sort text field from AdminHelp CMSFields
