### PR TITLE
fix relative links, soft error handling

### DIFF
--- a/code/controllers/AdminHelpController.php
+++ b/code/controllers/AdminHelpController.php
@@ -40,8 +40,4 @@ class AdminHelpController extends LeftAndMain implements PermissionProvider
 	public function MemberCanEdit() {
 		return Permission::check(array('ADMIN', 'ADMINHELP_ACCESS_EDIT'));
 	}
-
-	public static function help_link($uid) {
-		return Controller::join_links('/admin/admin-help/show/help', AdminHelp::by_uid($uid)->ID);
-	}
 }

--- a/code/forms/AdminHelpField.php
+++ b/code/forms/AdminHelpField.php
@@ -43,6 +43,10 @@ class AdminHelpField extends FormField
 	}
 
 	public function HelpLink() {
-		return AdminHelpController::help_link($this->uid);
+		return AdminHelp::by_uid($this->uid)->Link();
+	}
+
+	public function getUID(){
+		return $this->uid;
 	}
 }

--- a/code/models/AdminHelp.php
+++ b/code/models/AdminHelp.php
@@ -149,6 +149,15 @@ class AdminHelp extends DataObject
 	 * @return DataObject
 	 */
 	public static function by_uid($uid) {
-		return AdminHelp::get()->filter('UniqueIdentifier', $uid)->first();
+		return AdminHelp::get()->filter('UniqueIdentifier', $uid)->first();	
+	}
+
+	/**
+	 * Returns a link to view this AdminHelp item in the CMS
+	 *
+	 * @return String
+	 */
+	public function Link(){
+		return Controller::join_links('admin/admin-help/show/help', $this->ID);
 	}
 }

--- a/templates/Includes/AdminHelpList.ss
+++ b/templates/Includes/AdminHelpList.ss
@@ -1,7 +1,7 @@
 <ol class="admin-help-list">
     <% loop $RootHelpItems %>
         <li>
-            <a href="/admin/admin-help/show/help/$ID" <% if $Top.CurrentItem.ID == $ID %>class="current"<% end_if %>>$Title</a>
+            <a href="admin/admin-help/show/help/$ID" <% if $Top.CurrentItem.ID == $ID %>class="current"<% end_if %>>$Title</a>
             <% if $Summary %>
                 <div class="summary">$Summary</div>
             <% end_if %>
@@ -9,7 +9,7 @@
                 <ol>
                     <% loop $Children %>
                         <li>
-                            <a href="/admin/admin-help/show/help/$ID" <% if $Top.CurrentItem.ID == $ID %>class="current"<% end_if %>>$Title</a>
+                            <a href="admin/admin-help/show/help/$ID" <% if $Top.CurrentItem.ID == $ID %>class="current"<% end_if %>>$Title</a>
                             <% if $Summary %>
                                 <div class="summary">$Summary</div>
                             <% end_if %>

--- a/templates/Includes/AdminHelpShowController_Content.ss
+++ b/templates/Includes/AdminHelpShowController_Content.ss
@@ -27,13 +27,13 @@
     <div class="cms-content-actions cms-content-controls south">
         <% if $PreviousItem %>
             <% with $PreviousItem %>
-                <a href="/admin/admin-help/show/help/$ID" class="action ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">Previous "$Title"</a>
+                <a href="admin/admin-help/show/help/$ID" class="action ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">Previous "$Title"</a>
             <% end_with %>
         <% end_if %>
 
         <% if $NextItem %>
             <% with $NextItem %>
-                <a href="/admin/admin-help/show/help/$ID" class="action admin-help-right-button ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">Next "$Title"</a>
+                <a href="admin/admin-help/show/help/$ID" class="action admin-help-right-button ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only">Next "$Title"</a>
             <% end_with %>
         <% end_if %>
     </div>

--- a/templates/Includes/AdminHelpTabs.ss
+++ b/templates/Includes/AdminHelpTabs.ss
@@ -1,13 +1,13 @@
 <div class="cms-content-header-tabs">
     <ul class="ccms-content-header-tabs cms-tabset-nav-primary ss-ui-tabs-nav">
         <li class="<% if $class == 'AdminHelpController' || $class == 'AdminHelpShowController' %> ui-tabs-active<% end_if %>">
-            <a href="/admin/admin-help/view" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageEdit">
+            <a href="admin/admin-help/view" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageEdit">
                 <% _t('AdminHelp.TabView', 'Help') %>
             </a>
         </li>
         <% if $MemberCanEdit %>
         <li class="<% if $class == 'AdminHelpModelAdmin' %> ui-tabs-active<% end_if %>">
-            <a href="/admin/admin-help/edit" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageSettings">
+            <a href="admin/admin-help/edit" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageSettings">
                 <% _t('AdminHelp.TabEdit', 'Create/Edit') %>
             </a>
         </li>

--- a/templates/forms/AdminHelpField.ss
+++ b/templates/forms/AdminHelpField.ss
@@ -1,4 +1,10 @@
-<div class="field admin-help-field" title="Help for &quot;$HelpItem.Title.XML&quot;">
-    <a href="$HelpLink" target="_blank">$HelpText</a>
-    <a href="$HelpLink" target="_blank"><img src="adminhelp/images/help.png" alt="Help for &quot;$HelpItem.Title.XML&quot;"></a>
-</div>
+<% if HelpItem %>
+	<div class="field admin-help-field" title="Help for &quot;$HelpItem.Title.XML&quot;">
+	    <a href="$HelpLink" target="_blank">$HelpText</a>
+	    <a href="$HelpLink" target="_blank"><img src="adminhelp/images/help.png" alt="Help for &quot;$HelpItem.Title.XML&quot;"></a>
+	</div>
+<% else %>
+	<p class="message error">
+		AdminHelp item with Unique Identifier "$UID" not found.
+	</p>
+<% end_if %>


### PR DESCRIPTION
Relative links - SilverStripe instances installed into subdirectories (like my local dev set up) have trouble with absolute links coded like /admin/admin-help, I just removed the first slash to make them relative.

Soft error handling - SilverStripe was breaking/throwing an error when an AdminHelpField was created with an AdminHelp UID that didn't exist. I just put a check in place for this to show a warning message instead.
