### PR TITLE
custom sort onBeforeWrite causing sort problems

### DIFF
--- a/code/models/AdminHelp.php
+++ b/code/models/AdminHelp.php
@@ -132,17 +132,6 @@ class AdminHelp extends DataObject
 	}
 
 	/**
-	 * Make sure we have Sort
-	 */
-	public function onBeforeWrite() {
-		parent::onBeforeWrite();
-
-		if (!$this->Sort || $this->isChanged('ParentID')) {
-			$this->Sort = AdminHelp::get()->filter('ParentID', $this->ParentID)->max('Sort') + 1;
-		}
-	}
-
-	/**
 	 * Find a AdminHelp record by UniqueIdentifier
 	 *
 	 * @param string $uid


### PR DESCRIPTION
If I had for example (in this order) 2 normal help items, then 1 with children, then 2 normal ones, I was unable to move the bottom 2 normal ones above the 1 with children, it would just put them back to the bottom. 

I have removed the onBeforeWrite method which fixes the issue. I have tested sorting/reordering the items and there don't seem to be any side effects caused by making this change. 

Let me know if I've missed something but it seems we can safely get rid of the onBeforeWrite?
