### PR TITLE
toggleable help panels for AdminHelpField

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,9 @@
+AdminHelp:
+  extensions:
+    - Hierarchy
+
+LeftAndMain:
+  extra_requirements_javascript:
+    - "adminhelp/javascript/AdminHelp.js"
+  extra_requirements_css:
+    - "adminhelp/css/AdminHelp.css"

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,3 +1,0 @@
-AdminHelp:
-  extensions:
-    - Hierarchy

--- a/code/controllers/AdminHelpController.php
+++ b/code/controllers/AdminHelpController.php
@@ -16,13 +16,6 @@ class AdminHelpController extends LeftAndMain implements PermissionProvider
 
 	private static $required_permission_codes = array('ADMINHELP_ACCESS_VIEW');
 
-	public function init() {
-		parent::init();
-
-		Requirements::javascript(ADMINHELP_DIR . '/javascript/AdminHelp.js');
-		Requirements::css(ADMINHELP_DIR . '/css/AdminHelp.css');
-	}
-
 	public function RootHelpItems() {
 		return AdminHelp::get()->filter('ParentID', 0);
 	}

--- a/code/controllers/AdminHelpShowController.php
+++ b/code/controllers/AdminHelpShowController.php
@@ -18,12 +18,6 @@ class AdminHelpShowController extends AdminHelpController implements PermissionP
 		'help'
 	);
 
-	public function init() {
-		parent::init();
-
-		Requirements::css(ADMINHELP_DIR . '/css/AdminHelp.css');
-	}
-
 	public function HelpItem() {
 		return AdminHelp::get()->byID($this->getRequest()->param('ID'));
 	}

--- a/code/forms/AdminHelpField.php
+++ b/code/forms/AdminHelpField.php
@@ -9,6 +9,18 @@
 class AdminHelpField extends FormField
 {
 
+	/**
+	 * Whether help items should open in a new window by default
+	 * @var boolean
+	 **/
+	private static $new_window_default = false;
+
+	/**
+	 * Whether this help item should open in a new window
+	 * @var string|boolean
+	 **/
+	protected $newWindow;
+
 	protected $text;
 
 	protected $uid;
@@ -17,10 +29,12 @@ class AdminHelpField extends FormField
 	 * @param string $name Field name
 	 * @param null|string $text Short help link description
 	 * @param string $uid UniqueIdentifier for AdminHelp
+	 * @param string|boolean $inline Whether to open this item in a new window
 	 */
-	public function __construct($name, $text, $uid) {
+	public function __construct($name, $text, $uid, $newWindow='default') {
 		$this->text = $text;
 		$this->uid = $uid;
+		$this->newWindow = $newWindow;
 
 		parent::__construct($name);
 	}
@@ -30,7 +44,6 @@ class AdminHelpField extends FormField
 	}
 
 	public function Field($properties = array()) {
-		Requirements::css(ADMINHELP_DIR . '/css/AdminHelpField.css');
 		return $this->renderWith('AdminHelpField');
 	}
 
@@ -48,5 +61,14 @@ class AdminHelpField extends FormField
 
 	public function getUID(){
 		return $this->uid;
+	}
+
+	/**
+	 * Check if this help item should open in a new window
+	 * or inline in a dropdown
+	 * @return boolean
+	 **/
+	public function OpenInNewWindow(){
+		return $this->newWindow == 'default' ? $this->config()->new_window_default : $this->newWindow;
 	}
 }

--- a/css/AdminHelp.css
+++ b/css/AdminHelp.css
@@ -24,4 +24,4 @@ ol.admin-help-list li a.current { color: #000; }
 .admin-help-typography ol { list-style-type: decimal; }
 
 .admin-help-field img { height: 20px; width: auto; vertical-align: text-bottom; margin-left: 10px; }
-.admin-help-field .admin-help-field-content { background: #fff; padding: 20px 20px 10px; margin-top: 20px; border: 1px solid #ccc; border-radius: 5px; }
+.admin-help-field .admin-help-field-content { display: none; background: #fff; padding: 20px 20px 10px; margin-top: 20px; border: 1px solid #ccc; border-radius: 5px; }

--- a/css/AdminHelp.css
+++ b/css/AdminHelp.css
@@ -10,12 +10,18 @@ ol.admin-help-list li a.current { color: #000; }
 .admin-help-right-button { float: right; }
 
 #admin-help-controller-cms-content .cms-edit-form { overflow: scroll; }
-#admin-help-controller-cms-content .cms-edit-form h1 { font-size: 28px; font-weight: bold; margin: 0 0 20px; }
-#admin-help-controller-cms-content .cms-edit-form h2 { font-size: 25px; font-weight: normal; margin: 0 0 20px; }
-#admin-help-controller-cms-content .cms-edit-form h3 { font-size: 22px; font-weight: normal; margin: 0 0 20px; }
-#admin-help-controller-cms-content .cms-edit-form h4 { font-size: 18px; font-weight: normal; margin: 0 0 20px; }
-#admin-help-controller-cms-content .cms-edit-form h5 { font-size: 15px; font-weight: normal; margin: 0 0 20px; }
-#admin-help-controller-cms-content .cms-edit-form p { font-size: 15px; line-height: 1.7; margin: 0 0 16px; }
-#admin-help-controller-cms-content .cms-edit-form p + h1, #admin-help-controller-cms-content .cms-edit-form p + h2, #admin-help-controller-cms-content .cms-edit-form p + h3, #admin-help-controller-cms-content .cms-edit-form p + h4, #admin-help-controller-cms-content .cms-edit-form p + h5 { margin-top: 30px; }
-#admin-help-controller-cms-content .cms-edit-form ul { font-size: 15px; line-height: 1.8; list-style: disc; margin: 20px 0 20px 20px; }
-#admin-help-controller-cms-content .cms-edit-form ul + h1, #admin-help-controller-cms-content .cms-edit-form ul + h2, #admin-help-controller-cms-content .cms-edit-form ul + h3, #admin-help-controller-cms-content .cms-edit-form ul + h4, #admin-help-controller-cms-content .cms-edit-form ul + h5 { margin-top: 30px; }
+
+.admin-help-typography h1 { font-size: 28px; font-weight: bold; margin: 0 0 20px; }
+.admin-help-typography h2 { font-size: 25px; font-weight: normal; margin: 0 0 20px; }
+.admin-help-typography h3 { font-size: 22px; font-weight: normal; margin: 0 0 20px; }
+.admin-help-typography h4 { font-size: 18px; font-weight: normal; margin: 0 0 20px; }
+.admin-help-typography h5 { font-size: 15px; font-weight: normal; margin: 0 0 20px; }
+.admin-help-typography p { font-size: 15px; line-height: 1.7; margin: 0 0 16px; }
+.admin-help-typography p + h1, .admin-help-typography p + h2, .admin-help-typography p + h3, .admin-help-typography p + h4, .admin-help-typography p + h5 { margin-top: 30px; }
+.admin-help-typography ul, .admin-help-typography ol { font-size: 15px; line-height: 1.8; margin: 20px 0 20px 20px; }
+.admin-help-typography ul + h1, .admin-help-typography ul + h2, .admin-help-typography ul + h3, .admin-help-typography ul + h4, .admin-help-typography ul + h5, .admin-help-typography ol + h1, .admin-help-typography ol + h2, .admin-help-typography ol + h3, .admin-help-typography ol + h4, .admin-help-typography ol + h5 { margin-top: 30px; }
+.admin-help-typography ul { list-style-type: disc; }
+.admin-help-typography ol { list-style-type: decimal; }
+
+.admin-help-field img { height: 20px; width: auto; vertical-align: text-bottom; margin-left: 10px; }
+.admin-help-field .admin-help-field-content { background: #fff; padding: 20px 20px 10px; margin-top: 20px; border: 1px solid #ccc; border-radius: 5px; }

--- a/css/AdminHelpField.css
+++ b/css/AdminHelpField.css
@@ -1,1 +1,0 @@
-.admin-help-field img { height: 20px; width: auto; vertical-align: text-bottom; margin-left: 10px; }

--- a/javascript/AdminHelp.js
+++ b/javascript/AdminHelp.js
@@ -7,5 +7,12 @@
 				if(!$('.cms-container').loadPanel(this.attr('href'))) return false;
 			}
 		});
+
+		$('.admin-help-field-toggle').entwine({
+			onclick:function(e) {
+				e.preventDefault();
+				this.parent().find('.admin-help-field-content').slideToggle(0);
+			}
+		});
 	});
 })(jQuery);

--- a/scss/AdminHelp.scss
+++ b/scss/AdminHelp.scss
@@ -53,56 +53,84 @@ ol.admin-help-list {
 #admin-help-controller-cms-content{
 	.cms-edit-form{
 		overflow: scroll;
-
-		h1{
-			font-size: 28px;
-			font-weight: bold;
-			margin: 0 0 20px;
-		}
-
-		h2{
-			font-size: 25px;
-			font-weight: normal;
-			margin: 0 0 20px;
-		}
-
-		h3{
-			font-size: 22px;
-			font-weight: normal;
-			margin: 0 0 20px;
-		}
-
-		h4{
-			font-size: 18px;
-			font-weight: normal;
-			margin: 0 0 20px;
-		}
-
-		h5{
-			font-size: 15px;
-			font-weight: normal;
-			margin: 0 0 20px;
-		}
-
-		p{
-			font-size: 15px;
-			line-height: 1.7;
-			margin: 0 0 16px; 
-
-			+ h1, + h2, + h3, + h4, +h5{
-		        margin-top: 30px;
-		    }
-		}
-
-		ul{
-			font-size: 15px;
-			line-height: 1.8;
-			list-style: disc;
-			margin: 20px 0 20px 20px;
-
-			+ h1, + h2, + h3, + h4, +h5{
-		        margin-top: 30px;
-		    }
-		}
 	}
 }
+
+.admin-help-typography{
+	h1{
+		font-size: 28px;
+		font-weight: bold;
+		margin: 0 0 20px;
+	}
+
+	h2{
+		font-size: 25px;
+		font-weight: normal;
+		margin: 0 0 20px;
+	}
+
+	h3{
+		font-size: 22px;
+		font-weight: normal;
+		margin: 0 0 20px;
+	}
+
+	h4{
+		font-size: 18px;
+		font-weight: normal;
+		margin: 0 0 20px;
+	}
+
+	h5{
+		font-size: 15px;
+		font-weight: normal;
+		margin: 0 0 20px;
+	}
+
+	p{
+		font-size: 15px;
+		line-height: 1.7;
+		margin: 0 0 16px; 
+
+		+ h1, + h2, + h3, + h4, +h5{
+	        margin-top: 30px;
+	    }
+	}
+
+	ul, ol{
+		font-size: 15px;
+		line-height: 1.8;
+		margin: 20px 0 20px 20px;
+
+		+ h1, + h2, + h3, + h4, +h5{
+	        margin-top: 30px;
+	    }
+	}
+
+	ul {
+	    list-style-type: disc;  
+	}
+
+	ol {
+	    list-style-type: decimal;  
+	} 
+}
+
+
+.admin-help-field {
+	img {
+		height:20px;
+		width:auto;
+		vertical-align:text-bottom;
+		margin-left:10px;
+	}
+
+	.admin-help-field-content{
+		background: #fff;
+		padding: 20px 20px 10px;
+		margin-top: 20px;
+		border: 1px solid #ccc;
+		border-radius: 5px;
+	}
+}
+

--- a/scss/AdminHelp.scss
+++ b/scss/AdminHelp.scss
@@ -126,6 +126,7 @@ ol.admin-help-list {
 	}
 
 	.admin-help-field-content{
+		display: none;
 		background: #fff;
 		padding: 20px 20px 10px;
 		margin-top: 20px;

--- a/scss/AdminHelpField.scss
+++ b/scss/AdminHelpField.scss
@@ -1,8 +1,0 @@
-.admin-help-field {
-	img {
-		height:20px;
-		width:auto;
-		vertical-align:text-bottom;
-		margin-left:10px;
-	}
-}

--- a/templates/Includes/AdminHelpShowController_Content.ss
+++ b/templates/Includes/AdminHelpShowController_Content.ss
@@ -18,8 +18,10 @@
     <div class="cms-edit-form cms-panel-padded center ui-tabs-panel ui-widget-content ui-corner-bottom" data-layout-type="border">
             <div id="Form_EditForm"></div>
             <% with $HelpItem %>
-                <h2>$Title</h2>
-                $Content
+                <div class="admin-help-typography">
+                    <h2>$Title</h2>
+                    $Content
+                </div>
             <% end_with %>
 
     </div>

--- a/templates/forms/AdminHelpField.ss
+++ b/templates/forms/AdminHelpField.ss
@@ -1,7 +1,16 @@
 <% if HelpItem %>
 	<div class="field admin-help-field" title="Help for &quot;$HelpItem.Title.XML&quot;">
-	    <a href="$HelpLink" target="_blank">$HelpText</a>
-	    <a href="$HelpLink" target="_blank"><img src="adminhelp/images/help.png" alt="Help for &quot;$HelpItem.Title.XML&quot;"></a>
+	    <% if OpenInNewWindow %>
+	    	<a href="$HelpLink" target="_blank">$HelpText</a>
+	    	<a href="$HelpLink" target="_blank"><img src="adminhelp/images/help.png" alt="Help for &quot;$HelpItem.Title.XML&quot;"></a>
+	    <% else %>
+	    	<a class="admin-help-field-toggle" href="$HelpLink" target="_blank">$HelpText</a>
+	    	<a class="admin-help-field-toggle" href="$HelpLink" target="_blank"><img src="adminhelp/images/help.png" alt="Help for &quot;$HelpItem.Title.XML&quot;"></a>
+	    	<div class="admin-help-field-content admin-help-typography">
+	    		<h2>$HelpItem.Title</h2>
+	    		$HelpItem.Content
+	    	</div>
+	    <% end_if %>
 	</div>
 <% else %>
 	<p class="message error">


### PR DESCRIPTION
- Added ability for AdminHelpField to display the help item in context (in-page toggleable panel rather than opening a new tab)
- Whether the help opens in a toggleable panel or new window is configurable both globally and on a per field basis
- Consolidated css and js files, mainly becuase AminHelp.css now contains typography styles that are applied in the AdminHelp View controller/section, as well as the AdminHelpField toggleable panels.  
